### PR TITLE
Reference Patterns in a FontSet

### DIFF
--- a/fontconfig.py
+++ b/fontconfig.py
@@ -1520,6 +1520,7 @@ class FontSet :
         f = ct.cast(self._fcobj, ct.POINTER(FC.FontSet))
         pats = ct.cast(f[0].fonts, ct.POINTER(ct.c_void_p))
         for i in range(f[0].nfont) :
+            fc.FcPatternReference(pats[i])
             yield Pattern(pats[i])
         #end for
     #end each


### PR DESCRIPTION
When FontSets are converted to python lists, the original FontSet gets destroyed.
At least with fontconfig 2.13.1 on Arch Linux this causes the Pattern objects being destroyed with it and accessing them fails with a segfault. 
This patch references the Pattern objects, so they won't get destroyed.